### PR TITLE
Slack /dnd 功能

### DIFF
--- a/capability-checklist.md
+++ b/capability-checklist.md
@@ -1,3 +1,14 @@
+Slack中'/dnd'的用法：  
+意即开启或者关闭免打扰模式（Do Not Disturb）  
+免打扰固定时间： /dnd for sometime   example: /dnd for 15 minutes
+在某个时间点之前免打扰: /dnd until sometime  example: /dnd until 2:15  
+                                                    /dnd until tonight  
+                                                    /dnd until tomorrow morning
+                                    
+
+
+
+
 TODO:   
 Linux命令行  
    文件处理相关：TLCL 前六章  

--- a/capability-checklist.md
+++ b/capability-checklist.md
@@ -1,4 +1,7 @@
-TODO: 添加实习生内训结束时需要掌握的技能点
+TODO: Linux命令行
+文件处理相关：
+
+
 
 TODO: 将该checklist的记录和PR流程加入到工作流中
 

--- a/capability-checklist.md
+++ b/capability-checklist.md
@@ -1,6 +1,8 @@
-TODO: Linux命令行
-文件处理相关：
-
+TODO:   
+Linux命令行  
+   文件处理相关：TLCL 前六章  
+Progit  
+   前三章
 
 
 TODO: 将该checklist的记录和PR流程加入到工作流中


### PR DESCRIPTION
/dnd
Use `/dnd` to turn Do Not Disturb on and off. Some examples include:
/dnd for 15 minutes
/dnd until 2:15
/dnd until tonight
/dnd until tomorrow morning